### PR TITLE
Fixes for evtchn and xen_shell in zephyr-xenlib

### DIFF
--- a/xen-dom-mgmt/src/xen-dom-mgmt.c
+++ b/xen-dom-mgmt/src/xen-dom-mgmt.c
@@ -78,7 +78,7 @@ static int allocate_domain_evtchns(struct xen_domain *domain)
 	int rc;
 
 	/* TODO: Alloc all required evtchns */
-	rc = alloc_unbound_event_channel(domain->domid);
+	rc = alloc_unbound_event_channel_dom0(domain->domid, 0);
 	if (rc < 0) {
 		printk("failed to alloc evtchn for domain #%d xenstore, rc = %d\n", domain->domid,
 		       rc);
@@ -89,7 +89,7 @@ static int allocate_domain_evtchns(struct xen_domain *domain)
 	printk("Generated remote_domid=%d, xenstore_evtchn=%d\n", domain->domid,
 	       domain->xenstore_evtchn);
 
-	rc = alloc_unbound_event_channel(domain->domid);
+	rc = alloc_unbound_event_channel_dom0(domain->domid, 0);
 	if (rc < 0) {
 		printk("failed to alloc evtchn for domain #%d console, rc = %d\n", domain->domid,
 		       rc);

--- a/xen-shell-cmd/src/xen_shell.c
+++ b/xen-shell-cmd/src/xen_shell.c
@@ -71,8 +71,9 @@ void console_read_thrd(void *dom, void *p2, void *p3)
 					      sizeof(buffer) - nlpos - 1);
 			if (recv) {
 				memcpy(out, buffer, recv);
-				// disable temporary
-				//				printk("%s", buffer);
+
+				/* Transfer output to Zephyr Dom0 console */
+				printk("%s", buffer);
 			}
 		} while (recv);
 	}

--- a/xen-shell-cmd/src/xen_shell.c
+++ b/xen-shell-cmd/src/xen_shell.c
@@ -88,9 +88,13 @@ int init_domain_console(struct xen_domain *domain)
 {
 	int rc = 0;
 
-	domain->local_console_evtchn =
-		bind_interdomain_event_channel(domain->domid, domain->console_evtchn,
+	rc = bind_interdomain_event_channel(domain->domid, domain->console_evtchn,
 					       evtchn_callback, domain);
+
+	if (rc < 0)
+		return rc;
+
+	domain->local_console_evtchn = rc;
 
 	k_sem_init(&domain->console_sem, 1, 1);
 
@@ -103,8 +107,6 @@ int init_domain_console(struct xen_domain *domain)
 		printk("Failed to set domain console evtchn param, rc= %d\n", rc);
 		return rc;
 	}
-
-	rc = bind_event_channel(domain->local_console_evtchn, evtchn_callback, domain);
 
 	return rc;
 }

--- a/xenstore-srv/src/xenstore_srv.c
+++ b/xenstore-srv/src/xenstore_srv.c
@@ -665,10 +665,15 @@ int start_domain_stored(struct xen_domain *domain)
 	int rc = 0;
 
 	k_sem_init(&domain->xb_sem, 0, 1);
-	domain->local_xenstore_evtchn = bind_interdomain_event_channel(domain->domid,
+	rc = bind_interdomain_event_channel(domain->domid,
 								       domain->xenstore_evtchn,
 								       xs_evtchn_cb,
 								       (void *)domain);
+
+	if (rc < 0)
+		return rc;
+
+	domain->local_xenstore_evtchn = rc;
 
 	rc = hvm_set_parameter(HVM_PARAM_STORE_EVTCHN, domain->domid, domain->xenstore_evtchn);
 	if (rc) {


### PR DESCRIPTION
This PR adds few fixes for zephyr-xenlib:
1. Use proper allocation functions for pre-defined domain event channels.
2. Properly handle event channel binding for hvc/xenbus.
3. Enable domain output redirection to Zephyr Dom0 console.